### PR TITLE
10 add geospatial db

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ First, install [Docker](https://www.docker.com/).
 
 Spin up a database container with the command:
 ```shell
-docker run --name django-postgis -e POSTGRES_PASSWORD=testdjango -p:8080::5432 -d mdillon/postgis
+docker run --name django-postgis -e POSTGRES_PASSWORD=testdjango -p:8080:5432 -d mdillon/postgis
 ```
 
 Connect to the server to create the database:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,37 @@
 
 An open source campaign management app written in python using Django.
 
+## Installation
+
+### GeoDjango
+The app uses Django's build in GIS system, geodjango. See the documentation for [setup details](https://docs.djangoproject.com/en/2.0/ref/contrib/gis/install/)
+
+### Docker Database
+A dockerfile with PostGIS can be used for the geospatial database, simplifying some of the setup.
+**CAUTION: don't use in deployment! This setup does not persist data outside the container!**
+
+First, install [Docker](https://www.docker.com/).
+
+Spin up a database container with the command:
+```shell
+docker run --name django-postgis -e POSTGRES_PASSWORD=testdjango -p:8080::5432 -d mdillon/postgis
+```
+
+Connect to the server to create the database:
+```shell
+docker run -it --link django-postgis:postgis postgres psql -h postgres -U postgres
+```
+and the password from above. (This password can also be set using the `POSTGIS_PASSWORD` environment variable.)
+
+Once you're logged in, create the database:
+```sql
+CREATE DATABASE geodjango;
+\q
+```
+
+Verify that the settings in `config.setting.base` match what you configured, then everything should be good to go.
+
+## Contributing
 This project is under development.  To contribute, visit the [wiki](https://github.com/Camp-Otter/camp-otter/wiki).
 
 Use the [development branch](https://github.com/Camp-Otter/camp-otter/tree/development) to contribute code.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docker run --name django-postgis -e POSTGRES_PASSWORD=testdjango -p:8080::5432 -
 
 Connect to the server to create the database:
 ```shell
-docker run -it --link django-postgis:postgis postgres psql -h postgres -U postgres
+docker run -it --link django-postgis:postgres postgres psql -h postgres -U postgres
 ```
 and the password from above. (This password can also be set using the `POSTGIS_PASSWORD` environment variable.)
 

--- a/camp_otter/core/models.py
+++ b/camp_otter/core/models.py
@@ -1,6 +1,8 @@
 from django.contrib.gis.db import models
 from django.core.validators import RegexValidator
 
+from geopy.geocoders import Nominatim
+
 
 class Place(models.Model):
     place_name = models.CharField(max_length=250, blank=True)  # optional field for place name
@@ -10,6 +12,16 @@ class Place(models.Model):
     city = models.CharField(max_length=250)
     state = models.CharField(max_length=2)
     zip_code = models.CharField(max_length=5)
+
+    point = models.PointField(default='POINT(0.0 0.0)')
+
+    def geocode(self):
+        geolocator = Nominatim()
+        address_string = self.street_address + ', ' + self.city + ', ' + self.state
+        location = geolocator.geocode(address_string)
+        self.point.x = location.longitude
+        self.point.y = location.latitude
+        self.save()
 
     def __str__(self):
         address_string = ''

--- a/camp_otter/core/models.py
+++ b/camp_otter/core/models.py
@@ -1,4 +1,4 @@
-from django.db import models
+from django.contrib.gis.db import models
 from django.core.validators import RegexValidator
 
 

--- a/camp_otter/core/tests/test_models.py
+++ b/camp_otter/core/tests/test_models.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from django.core.exceptions import ValidationError
+from django.contrib.auth.models import User
 from camp_otter.core.models import Place, Person, ContactPhone, ContactEmail, Election, BallotQuestion, Campaign, CampaignStaff
 
 # Tests for core models
@@ -25,6 +26,12 @@ class PlaceModelTests(TestCase):
         person2 = Person(first_name='Joe', last_name='Test', residence=house)
         person2.save()
         self.assertQuerysetEqual(house.person_set.all(), [repr(person1), repr(person2)], ordered=False)
+
+    def test_spatial_field(self):
+        house = Place(street_address='1 Broadway', city='Newport', state='RI')
+        house.save()
+        house.geocode()
+        self.assertEqual(str(house.point.y), '41.490611')
 
 
 class PersonModelTests(TestCase):

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -39,6 +39,7 @@ DJANGO_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.gis',
 ]
 
 THIRD_PARTY_APPS = [
@@ -85,10 +86,16 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
 
+# Database is setup to connect to a networked docker container running postgis.
+# TODO: this needs to be updated if using docker compose
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, '../../db.sqlite3'),
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'NAME': 'geodjango',
+        'USER': 'postgres',
+        'PASSWORD': 'testdjango',
+        'HOST': 'localhost',
+        'PORT': '8080',
     }
 }
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -86,6 +86,8 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
 
+DB_PASSWORD = env('POSTGIS_PASSWORD', default='testdjango')
+
 # Database is setup to connect to a networked docker container running postgis.
 # TODO: this needs to be updated if using docker compose
 DATABASES = {
@@ -93,7 +95,7 @@ DATABASES = {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',
         'NAME': 'geodjango',
         'USER': 'postgres',
-        'PASSWORD': 'testdjango',
+        'PASSWORD': DB_PASSWORD,
         'HOST': 'localhost',
         'PORT': '8080',
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 pytz==2018.4  # https://github.com/stub42/pytz
 
+geopy==1.13
+
 # Django
 # ------------------------------------------------------------------------------
 django==2.0.3  # pyup: < 2.1  # https://www.djangoproject.com/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ pytz==2018.4  # https://github.com/stub42/pytz
 
 # Django
 # ------------------------------------------------------------------------------
-django==2.0.4  # pyup: < 2.1  # https://www.djangoproject.com/
+django==2.0.3  # pyup: < 2.1  # https://www.djangoproject.com/
 django-environ==0.4.4  # https://github.com/joke2k/django-environ


### PR DESCRIPTION
Addresses #10:

This update changes the default database to an external PostGIS database.  It has been tested using a local docker container running a postgis server, described in the README.

A new dependency on the geopy package and by extension the Nominatim geolocator has been added in `Place.geocode()`. The `Place` model now includes a `PointField` to store a point representation of the object in the database.